### PR TITLE
Added Blob and Container Listing utility functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = 'uk.gov.hmcts.reform.mi'
-version = '3.0.1'
+version = '3.0.2'
 sourceCompatibility = '11'
 
 bootJar {

--- a/src/main/java/uk/gov/hmcts/reform/mi/micore/component/IterableToListComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/mi/micore/component/IterableToListComponent.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.mi.micore.component;
+
+import com.azure.core.http.rest.PagedIterable;
+
+import java.util.List;
+
+public interface IterableToListComponent<T> {
+
+    List<T> getIterableAsList(PagedIterable<T> iterable);
+}

--- a/src/main/java/uk/gov/hmcts/reform/mi/micore/component/impl/BlobIterableToListComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/mi/micore/component/impl/BlobIterableToListComponent.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.mi.micore.component.impl;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobItem;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.mi.micore.component.IterableToListComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class BlobIterableToListComponent implements IterableToListComponent<BlobItem> {
+
+    @Override
+    public List<BlobItem> getIterableAsList(PagedIterable<BlobItem> iterable) {
+        List<BlobItem> blobList = new ArrayList<>();
+
+        iterable.forEach(blobList::add);
+
+        return blobList;
+    }
+
+    public List<BlobItem> getBlobsAsList(BlobServiceClient blobServiceClient, String containerName) {
+        return getIterableAsList(
+            blobServiceClient.getBlobContainerClient(containerName).listBlobs()
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/mi/micore/component/impl/ContainerIterableToListComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/mi/micore/component/impl/ContainerIterableToListComponent.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.mi.micore.component.impl;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobContainerItem;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.mi.micore.component.IterableToListComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ContainerIterableToListComponent implements IterableToListComponent<BlobContainerItem> {
+
+    @Override
+    public List<BlobContainerItem> getIterableAsList(PagedIterable<BlobContainerItem> iterable) {
+        List<BlobContainerItem> containerList = new ArrayList<>();
+
+        iterable.forEach(containerList::add);
+
+        return containerList;
+    }
+
+    public List<BlobContainerItem> getContainersAsList(BlobServiceClient blobServiceClient) {
+        return getIterableAsList(
+            blobServiceClient.listBlobContainers()
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/mi/micore/component/BlobIterableToListComponentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/mi/micore/component/BlobIterableToListComponentTest.java
@@ -1,0 +1,72 @@
+package uk.gov.hmcts.reform.mi.micore.component;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobItem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.mi.micore.component.impl.BlobIterableToListComponent;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+public class BlobIterableToListComponentTest {
+
+    private static final String TEST_CONTAINER_NAME = "test-container";
+
+    @InjectMocks
+    private BlobIterableToListComponent underTest;
+
+    @Test
+    public void givenPagedIterableBlobItems_whenGetIterableAsList_thenReturnListOfBlobItems() {
+        PagedIterable<BlobItem> blobItems = mock(PagedIterable.class);
+        Iterator<BlobItem> blobIterator = mock(Iterator.class);
+
+        doCallRealMethod().when(blobItems).forEach(any(Consumer.class));
+
+        when(blobItems.iterator()).thenReturn(blobIterator);
+
+        when(blobIterator.hasNext()).thenReturn(true, true, false);
+        when(blobIterator.next()).thenReturn(mock(BlobItem.class), mock(BlobItem.class));
+
+        List<BlobItem> result = underTest.getIterableAsList(blobItems);
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    public void givenBlobServiceClientAndContainerName_whenGetContainersAsList_thenReturnListOfBlobItems() {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+        BlobContainerClient blobContainerClient = mock(BlobContainerClient.class);
+
+        when(blobServiceClient.getBlobContainerClient(TEST_CONTAINER_NAME)).thenReturn(blobContainerClient);
+
+        PagedIterable<BlobItem> blobItems = mock(PagedIterable.class);
+
+        when(blobContainerClient.listBlobs()).thenReturn(blobItems);
+
+        Iterator<BlobItem> blobIterator = mock(Iterator.class);
+
+        doCallRealMethod().when(blobItems).forEach(any(Consumer.class));
+
+        when(blobItems.iterator()).thenReturn(blobIterator);
+
+        when(blobIterator.hasNext()).thenReturn(true, true, false);
+        when(blobIterator.next()).thenReturn(mock(BlobItem.class), mock(BlobItem.class));
+
+        List<BlobItem> result = underTest.getBlobsAsList(blobServiceClient, TEST_CONTAINER_NAME);
+
+        assertEquals(2, result.size());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/mi/micore/component/ContainerIterableToListComponentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/mi/micore/component/ContainerIterableToListComponentTest.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.reform.mi.micore.component;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobContainerItem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.mi.micore.component.impl.ContainerIterableToListComponent;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+public class ContainerIterableToListComponentTest {
+
+    @InjectMocks
+    private ContainerIterableToListComponent underTest;
+
+    @Test
+    public void givenPagedIterableContainerItems_whenGetIterableAsList_thenReturnListOfContainerItems() {
+        PagedIterable<BlobContainerItem> blobContainerItems = mock(PagedIterable.class);
+        Iterator<BlobContainerItem> blobContainerIterator = mock(Iterator.class);
+
+        doCallRealMethod().when(blobContainerItems).forEach(any(Consumer.class));
+
+        when(blobContainerItems.iterator()).thenReturn(blobContainerIterator);
+
+        when(blobContainerIterator.hasNext()).thenReturn(true, true, false);
+        when(blobContainerIterator.next()).thenReturn(mock(BlobContainerItem.class), mock(BlobContainerItem.class));
+
+        List<BlobContainerItem> result = underTest.getIterableAsList(blobContainerItems);
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    public void givenBlobServiceClientAndContainerName_whenGetContainersAsList_thenReturnListOfblobContainerItems() {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+
+        PagedIterable<BlobContainerItem> blobContainerItems = mock(PagedIterable.class);
+
+        when(blobServiceClient.listBlobContainers()).thenReturn(blobContainerItems);
+
+        Iterator<BlobContainerItem> blobContainerIterator = mock(Iterator.class);
+
+        doCallRealMethod().when(blobContainerItems).forEach(any(Consumer.class));
+
+        when(blobContainerItems.iterator()).thenReturn(blobContainerIterator);
+
+        when(blobContainerIterator.hasNext()).thenReturn(true, true, false);
+        when(blobContainerIterator.next()).thenReturn(mock(BlobContainerItem.class), mock(BlobContainerItem.class));
+
+        List<BlobContainerItem> result = underTest.getContainersAsList(blobServiceClient);
+
+        assertEquals(2, result.size());
+    }
+}


### PR DESCRIPTION
Working with PagedIterables may sometimes require effort regarding checking list size, getting specific indexes etc.

This adds some helper functions to convert or get containers / blobs as a List type instead.