### PR TITLE
Get kubernetes job name from deployment name

### DIFF
--- a/pipeline-steps/templates/kubernetes-wait-for-job.yaml
+++ b/pipeline-steps/templates/kubernetes-wait-for-job.yaml
@@ -10,11 +10,12 @@ steps:
       applicationName: ${{ parameters.jobName }}
   - bash: |
       timeout=600
-      job=$(jobName)
+      deploymentBuild=$(deploymentName)
+      job=$(kubectl get jobs --namespace ${{ parameters.namespace }} -o name | grep $deploymentBuild -m1)
       until [[ $SECONDS -gt $timeout ]] \
-        || [[ $(kubectl get jobs $job --namespace ${{ parameters.namespace }} \
+        || [[ $(kubectl get $job --namespace ${{ parameters.namespace }} \
             -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}') == 'True' ]] \
-        || [[ $(kubectl get jobs $job --namespace ${{ parameters.namespace }} \
+        || [[ $(kubectl get $job --namespace ${{ parameters.namespace }} \
             -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}') == 'True' ]];
       do
         echo "Waiting for job $job completion"

--- a/pipeline-steps/templates/kubernetes-wait-for-job.yaml
+++ b/pipeline-steps/templates/kubernetes-wait-for-job.yaml
@@ -11,7 +11,7 @@ steps:
   - bash: |
       timeout=600
       deploymentBuild=$(deploymentName)
-      job=$(kubectl get jobs --namespace ${{ parameters.namespace }} -o name | grep $deploymentBuild -m1)
+      job=$(kubectl get jobs --namespace ${{ parameters.namespace }} -o name | grep $deploymentBuild | tail -1)
       until [[ $SECONDS -gt $timeout ]] \
         || [[ $(kubectl get $job --namespace ${{ parameters.namespace }} \
             -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}') == 'True' ]] \

--- a/pipeline-steps/templates/steps/helm-job-name.yaml
+++ b/pipeline-steps/templates/steps/helm-job-name.yaml
@@ -7,12 +7,10 @@ steps:
   - bash: |
       buildName=${{ parameters.applicationName }}-$(imageSha)-b$(Build.BuildId)
       echo "##vso[task.setvariable variable=deploymentName]${buildName}"
-      echo "##vso[task.setvariable variable=jobName]${buildName}-mi-job"
-    displayName: 'Set job name'
+    displayName: 'Set deployment name'
   # Everything else: Set the tag to the environment name
 
   - bash: |
-        echo "Job name is: $(jobName)"
         echo "Deplyment name is: $(deploymentName)"
 
-    displayName: 'Display Job name'
+    displayName: 'Display Deployment name'


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Currently the job retrieval is hardcoded to -mi-job. This means if we use the CNP job chart, or any other job chart not mi-job, the project pipeline will fail.
This PR dynamically retrieves the job associated with the deployment id set to install the job.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
