### PR TITLE
Add ccd-data-store-db-connection-string as processable secret

### DIFF
--- a/pipeline-steps/scripts/mi-set-secrets.yaml
+++ b/pipeline-steps/scripts/mi-set-secrets.yaml
@@ -92,3 +92,5 @@ stages:
                   env_var_name: encryption-private-key
                 - secret_name: encryption-private-phase
                   env_var_name: encryption-private-phase
+                - secret_name: ccd-data-store-db-connection-string
+                  env_var_name: ccd-data-store-db-connection-string


### PR DESCRIPTION
Needed for ADF CCD Linked Service.
Using connection string secret instead of host and user + password as that combination requires immediately publishing of the data factory when creating the Linked Service in a Git Repo configuration scenario. This can make parallel development harder.

This secret has already been prepared in the Azure Pipelines variable groups for every environment except sbox.