### PR TITLE
Add configurable depends on so control job sequence

### DIFF
--- a/pipeline-steps/templates/jobs/integration-tests-job.yaml
+++ b/pipeline-steps/templates/jobs/integration-tests-job.yaml
@@ -27,11 +27,14 @@ parameters:
 - name: envMapping
   type: object
   default: {}
+- name: dependsOn
+  type: string
+  default: 'deploy_adf'
 
 jobs:
 - job: run_integration_tests
   displayName: 'Run integration tests'
-  dependsOn: deploy_adf
+  dependsOn: ${{ parameters.dependsOn }}
   pool: ${{ parameters.agentPool }}
 
   variables:

--- a/pipeline-steps/templates/jobs/smoke-tests-job.yaml
+++ b/pipeline-steps/templates/jobs/smoke-tests-job.yaml
@@ -31,11 +31,14 @@ parameters:
   type: string
 - name: sqlServerPasswordNameKey
   type: string
+- name: dependsOn
+  type: string
+  default: 'deploy_adf'
 
 jobs:
 - job: run_smoke_tests
   displayName: 'Run smoke tests'
-  dependsOn: deploy_adf
+  dependsOn: ${{ parameters.dependsOn }}
   pool: ${{ parameters.agentPool }}
 
   variables:


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

This allows overriding the dependsOn for integration and smoke tests so their execution order can be controlled.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
