### PR TITLE
Removed requirement for sp.username and sp.password

### DIFF
--- a/pipeline-steps/templates/promote-build.yaml
+++ b/pipeline-steps/templates/promote-build.yaml
@@ -14,4 +14,4 @@ steps:
       inlineScript: |
         sourceImage=${{ parameters.azureContainerRegistry }}/${{ parameters.applicationName }}:$(imageTag)
         targetImage=${{ parameters.applicationName }}:${{ parameters.promEnv }}-$(imageSha)
-        az acr import -n  ${{ parameters.azureDestinyContainerRegistry }} --source $sourceImage --image $targetImage --username  $(sp.user) --password $(sp.password) 
+        az acr import -n  ${{ parameters.azureDestinyContainerRegistry }} --source $sourceImage --image $targetImage


### PR DESCRIPTION
Needed for promoting images with prod tag in sdshmctspublic
For mi-azure-functions use.