### PR TITLE
Fix trigger script

### DIFF
--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -112,6 +112,7 @@ jobs:
           displayName: 'Enable or Disable Pipeline Triggers'
           inputs:
             azureSubscription: ${{ parameters.subscriptionEndpoint }}
+            azurePowerShellVersion: LatestVersion
             scriptType: 'inline'
             inline: |
               $triggersADF = Get-AzDataFactoryV2Trigger -DataFactoryName "${{ parameters.adfName }}" -ResourceGroupName "${{ parameters.resourceGroup }}"

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -112,6 +112,7 @@ jobs:
           displayName: 'Enable or Disable Pipeline Triggers'
           inputs:
             azureSubscription: ${{ parameters.subscriptionEndpoint }}
+            scriptType: 'inline'
             inline: |
               $triggersADF = Get-AzDataFactoryV2Trigger -DataFactoryName "${{ parameters.adfName }}" -ResourceGroupName "${{ parameters.resourceGroup }}"
               $triggersADF | ForEach-Object {

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -47,7 +47,7 @@ jobs:
               pwsh --command Install-Module -Name Az.Accounts -RequiredVersion 2.1.2 -AllowClobber -Force
               pwsh --command Install-Module -Name Az.DataFactory -RequiredVersion 1.11.4 -AllowClobber -Force
         - task: AzurePowerShell@4
-          displayName: 'Azure PowerShell script: Stop ADF triggers'
+          displayName: 'Azure PowerShell script: Use preDeploymentScript and stop ADF triggers'
           inputs:
             azureSubscription: ${{ parameters.subscriptionEndpoint }}
             ScriptPath: '$(Pipeline.Workspace)/ArmTemplates/PrePostDeploymentScript.ps1'
@@ -102,10 +102,23 @@ jobs:
             csmParametersFile: '$(Pipeline.Workspace)/ArmTemplates/ARMTemplateParametersForFactory.json'
             overrideParameters: -factoryName ${{ parameters.adfName }} ${{ parameters.adfOverrideParameters }}
         - task: AzurePowerShell@4
-          displayName: 'Azure PowerShell script: Start ADF triggers'
-          condition: eq(${{ parameters.enableTriggers }}, true)
+          displayName: 'Azure PowerShell script: Start PostDeploymentScript'
           inputs:
             azureSubscription: ${{ parameters.subscriptionEndpoint }}
             ScriptPath: '$(Pipeline.Workspace)/ArmTemplates/PrePostDeploymentScript.ps1'
             ScriptArguments: '-armTemplate "$(Pipeline.Workspace)/ArmTemplates/ARMTemplateForFactory.json" -ResourceGroupName "${{ parameters.resourceGroup }}" -DataFactoryName "${{ parameters.adfName }}" -predeployment $false'
             azurePowerShellVersion: LatestVersion
+        - task: AzurePowerShell@4
+          displayName: 'Enable or Disable Pipeline Triggers'
+          inputs:
+            azureSubscription: ${{ parameters.subscriptionEndpoint }}
+            inline: |
+              $triggersADF = Get-AzDataFactoryV2Trigger -DataFactoryName "${{ parameters.adfName }}" -ResourceGroupName "${{ parameters.resourceGroup }}"
+              $triggersADF | ForEach-Object {
+                if ("${{ parameters.enableTriggers }}" -eq "true") {
+                  Start-AzDataFactoryV2Trigger -ResourceGroupName "${{ parameters.resourceGroup }}" -DataFactoryName "${{ parameters.adfName }}" -Name $_.name -Force
+                }
+                else {
+                  Stop-AzDataFactoryV2Trigger -ResourceGroupName "${{ parameters.resourceGroup }}" -DataFactoryName "${{ parameters.adfName }}" -Name $_.name -Force
+                }
+              }


### PR DESCRIPTION
### Change description ###

This now always calls the post deployment script defined by Microsoft to do proper post deployment cleanup.
Instead a parameter is used to determine whether to enable or disable triggers post deployment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
