### PR TITLE
Fixed adfOverrides with special characters

### DIFF
--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -92,15 +92,9 @@ jobs:
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
         
-        #- script: echo "$(adfOverrideParams)"
-        #  displayName: "List override parameters"
-        - task: Powershell@2
-          displayName: "List override parameter"
-          inputs:
-            targetType: 'inline'
-            script: |
-              $adfParams = "$(adfOverrideParams) -replace ';', '\;'"
-              Write-Output $adfParams
+        - script: echo "$(adfOverrideParams)"
+          displayName: "List override parameters"
+
         
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -32,7 +32,7 @@ jobs:
   variables:
     packageWheelName: 'none'
     adfOverrideTemp: ${{ parameters.adfOverrideParameters }}
-    adfOverrideParams: $[replace(variables.adfOverrideTemp, ";", "\;")]
+    adfOverrideParams: $[replace(variables.adfOverrideTemp, ';', '\;')]
   environment: ${{ parameters.env }}
   strategy:
     runOnce:

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -31,8 +31,7 @@ jobs:
 
   variables:
     packageWheelName: 'none'
-    adfOverrideTemp: ${{ parameters.adfOverrideParameters }}
-    adfOverrideParams: $[replace(variables.adfOverrideTemp, ';', '\;')]
+    adfOverrideParams: ${{ parameters.adfOverrideParameters }}
   environment: ${{ parameters.env }}
   strategy:
     runOnce:
@@ -93,8 +92,15 @@ jobs:
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
         
-        - script: echo "$(adfOverrideParams)"
-          displayName: "List override parameters"
+        #- script: echo "$(adfOverrideParams)"
+        #  displayName: "List override parameters"
+        - task: Powershell@2
+          displayName: "List override parameter"
+          inputs:
+            targetType: 'inline'
+            script: |
+              $adfParams = "$(adfOverrideParams) -replace ';', '\;'"
+              Write-Output $adfParams
         
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -91,7 +91,7 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        - script: echo "$(adfOverrideParams)" -replace ";", "\;"
+        - script: echo "$replace(adfOverrideParams, ";", "\;")"
           displayName: "List override parameters"
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -91,7 +91,7 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        - script: echo "$[replace(variables['adfOverrideParams'], ';', '\;')]"
+        - script: echo "$[replace(variables.adfOverrideParams, ';', '\;')]"
           displayName: "List override parameters"
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -31,7 +31,8 @@ jobs:
 
   variables:
     packageWheelName: 'none'
-    adfOverrideParams: ${{ parameters.adfOverrideParameters }}
+    adfOverrideTemp: ${{ parameters.adfOverrideParameters }}
+    adfOverrideParams: $[replace(variables.adfOverrideTemp, ";", "\;")]
   environment: ${{ parameters.env }}
   strategy:
     runOnce:
@@ -91,8 +92,10 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        - script: echo "$replace(adfOverrideParams, ";", "\;")"
+        
+        - script: echo "$(adfOverrideParams)"
           displayName: "List override parameters"
+        
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'
           inputs:

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -31,7 +31,6 @@ jobs:
 
   variables:
     packageWheelName: 'none'
-    adfOverrideParams: ${{ parameters.adfOverrideParameters }}
   environment: ${{ parameters.env }}
   strategy:
     runOnce:

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -31,7 +31,7 @@ jobs:
 
   variables:
     packageWheelName: 'none'
-    adfOverrideParams: ${{ replace(parameters.adfOverrideParameters }}
+    adfOverrideParams: ${{ parameters.adfOverrideParameters }}
   environment: ${{ parameters.env }}
   strategy:
     runOnce:

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -31,7 +31,7 @@ jobs:
 
   variables:
     packageWheelName: 'none'
-    adfOverrideParams: $(parameters.adfOverrideParameters)
+    adfOverrideParams: ${{ replace(parameters.adfOverrideParameters }}
   environment: ${{ parameters.env }}
   strategy:
     runOnce:
@@ -91,7 +91,7 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        - script: echo "$(adfOverrideParams)"
+        - script: echo "$(adfOverrideParams)" -replace ";", "\;"
           displayName: "List override parameters"
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -90,7 +90,7 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        - script: echo "${{ parameters.adfOverrideParameters }}"
+        - script: echo "${{ replace(parameters.adfOverrideParameters, ';', '\;') }}"
           displayName: "List override parameters"
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -99,7 +99,7 @@ jobs:
             location: '$(azureLocation)'
             csmFile: '$(Pipeline.Workspace)/ArmTemplates/ARMTemplateForFactory.json'
             csmParametersFile: '$(Pipeline.Workspace)/ArmTemplates/ARMTemplateParametersForFactory.json'
-            overrideParameters: -factoryName ${{ parameters.adfName }} '${{ parameters.adfOverrideParameters }}'
+            overrideParameters: -factoryName ${{ parameters.adfName }} ${{ replace(parameters.adfOverrideParameters, '"', '\"') }}
         - task: AzurePowerShell@4
           displayName: 'Azure PowerShell script: Start PostDeploymentScript'
           inputs:

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -31,7 +31,7 @@ jobs:
 
   variables:
     packageWheelName: 'none'
-    adfOverrideParams: ${{ replace(parameters.adfOverrideParameters, ';', '\;') }} # deal with main escape chars
+    adfOverrideParams: ${{ parameters.adfOverrideParameters }} 
   environment: ${{ parameters.env }}
   strategy:
     runOnce:
@@ -91,7 +91,7 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        - script: echo "$(adfOverrideParams)"
+        - script: echo "$[replace(variables['adfOverrideParams'], ';', '\;')]"
           displayName: "List override parameters"
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -91,11 +91,6 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        
-        - script: echo "$(adfOverrideParams)"
-          displayName: "List override parameters"
-
-        
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'
           inputs:
@@ -104,7 +99,7 @@ jobs:
             location: '$(azureLocation)'
             csmFile: '$(Pipeline.Workspace)/ArmTemplates/ARMTemplateForFactory.json'
             csmParametersFile: '$(Pipeline.Workspace)/ArmTemplates/ARMTemplateParametersForFactory.json'
-            overrideParameters: -factoryName ${{ parameters.adfName }} ${{ parameters.adfOverrideParameters }}
+            overrideParameters: -factoryName ${{ parameters.adfName }} '${{ parameters.adfOverrideParameters }}'
         - task: AzurePowerShell@4
           displayName: 'Azure PowerShell script: Start PostDeploymentScript'
           inputs:

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -31,7 +31,7 @@ jobs:
 
   variables:
     packageWheelName: 'none'
-    adfOverrideParams: ${{ parameters.adfOverrideParameters }} 
+    adfOverrideParams: $(parameters.adfOverrideParameters)
   environment: ${{ parameters.env }}
   strategy:
     runOnce:
@@ -91,7 +91,7 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        - script: echo "$[replace(variables.adfOverrideParams, ';', '\;')]"
+        - script: echo "$(adfOverrideParams)"
           displayName: "List override parameters"
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -31,6 +31,7 @@ jobs:
 
   variables:
     packageWheelName: 'none'
+    adfOverrideParams: ${{ replace(parameters.adfOverrideParameters, ';', '\;') }} # deal with main escape chars
   environment: ${{ parameters.env }}
   strategy:
     runOnce:
@@ -90,7 +91,7 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        - script: echo "${{ replace(parameters.adfOverrideParameters, ';', '\;') }}"
+        - script: echo "$(adfOverrideParams)"
           displayName: "List override parameters"
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'


### PR DESCRIPTION
Escaping the double quotes makes the script treat the parameter as a proper string rather than attempting to interpolate it as a bash command.