### PR TITLE
Removed echo task for adf overrides

### DIFF
--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -90,6 +90,8 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
+        - script: printf "${{ parameters.adfOverrideParameters }}"
+          displayName: "List override parameters"
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'
           inputs:

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -90,8 +90,6 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        - script: printf "${{ parameters.adfOverrideParameters }}"
-          displayName: "List override parameters"
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'
           inputs:

--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -90,8 +90,6 @@ jobs:
             inline: |
               Get-AzDataFactoryV2 -ResourceGroupName "${{ parameters.resourceGroup }}" -Name "${{ parameters.adfName }}" | Set-AzDataFactoryV2 -HostName "https://github.com" -AccountName "$(RepoConfigurationAccountName)" -RepositoryName "$(RepoConfigurationRepositoryName)" -CollaborationBranch "$(RepoConfigurationCollaborationBranch)" -RootFolder "$(RepoConfigurationRootFolder)" -Force
             azurePowerShellVersion: LatestVersion
-        - script: echo "${{ parameters.adfOverrideParameters }}"
-          displayName: "List override parameters"
         - task: AzureResourceGroupDeployment@2
           displayName: 'Azure Deployment:Create Or Update Resource Group action on ${{ parameters.resourceGroup }}'
           inputs:


### PR DESCRIPTION
### Change description ###

It seems the format of some ADF properties don't work well with bash script and break on the echo, but works on the actual deployment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
