### PR TITLE
Fixed wrong rg reference in scope lock check

### DIFF
--- a/pipeline-steps/templates/jobs/deploy-adf-job.yaml
+++ b/pipeline-steps/templates/jobs/deploy-adf-job.yaml
@@ -56,7 +56,7 @@ jobs:
                 exit 1
               fi
 
-              exportLocks=$(az lock list -g "mi-ingestion-${{ parameters.env }}" -o tsv)
+              exportLocks=$(az lock list -g "mi-${{ parameters.env }}-rg" -o tsv)
               if [[ ! -z "$exportLocks" && $exportLocks==" " ]]; then
                 echo "Lock exists on export storage account resource group which will prevent updating the storage triggers."
                 exit 1


### PR DESCRIPTION
The ADF rg is the mi-ingestion so the export one to check should be mi-env-rg