### PR TITLE
Ad2 hour timeout for deployment-config-jon.yaml

### DIFF
--- a/pipeline-steps/templates/jobs/deployment-config-job.yaml
+++ b/pipeline-steps/templates/jobs/deployment-config-job.yaml
@@ -43,6 +43,7 @@ jobs:
   displayName: 'Run deployment config'
   dependsOn: ${{ parameters.dependsOn }}
   pool: ${{ parameters.agentPool }}
+  timeoutInMinutes: 120
 
   variables:
     pythonWorkingDir: './'


### PR DESCRIPTION
### Change description ###
Investigating a potential fix for the below error
https://dev.azure.com/hmcts/MI%20Reporting/_build/results?buildId=270467&view=logs&s=43c1b68a-8f84-5f6e-86de-5ace12db9f77&j=c467b416-fc6c-52d4-ebfd-bc6234699e47

Deployment of mi-synapse-core on a branch that references this one was successful


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
