### PR TITLE
Increase integration tests job timeout from default 60 minutes to 120 minutes

### DIFF
--- a/pipeline-steps/templates/jobs/integration-tests-job.yaml
+++ b/pipeline-steps/templates/jobs/integration-tests-job.yaml
@@ -33,6 +33,7 @@ jobs:
   displayName: 'Run integration tests'
   dependsOn: ${{ parameters.dependsOn }}
   pool: ${{ parameters.agentPool }}
+  timeoutInMinutes: 120
 
   variables:
     pythonWorkingDir: './'


### PR DESCRIPTION
Timing out the tests after 60 minutes when its still running fails the build and wastes time. We have been adding more and more integration tests so its taking this long now.
Preferably we should refactor as much of the existing int tests as possible and use the E2E tests instead for long running tests, but this is a quick fix.