### PR TITLE
Add generic python validation job using flake8

### DIFF
--- a/pipeline-steps/templates/jobs/validate-python-job.yml
+++ b/pipeline-steps/templates/jobs/validate-python-job.yml
@@ -10,7 +10,7 @@ parameters:
 jobs:
 - job: validate_python
   displayName: Validate python
-  pool: $(parameters.pool)
+  pool: ${{ parameters.pool }}
   steps:
   - task: AzureCLI@2
     displayName: 'Install dependencies and validate code'
@@ -24,7 +24,7 @@ jobs:
         pip3 install -U pip
         pip3 install -r requirements.txt --no-cache-dir
         printf "\n\n\n\n\nBeginning code validation\n"
-        flake8 $(parameters.testDirectory) || echo "Warning - The code has styling issues that must be resolved"
+        flake8 ${{ parameters.testDirectory }} || echo "Warning - The code has styling issues that must be resolved"
         echo "Code validation complete"
         deactivate
-      azureSubscription: $(parameters.azureSubscriptionName)
+      azureSubscription: ${{ parameters.azureSubscriptionName }}

--- a/pipeline-steps/templates/jobs/validate-python-job.yml
+++ b/pipeline-steps/templates/jobs/validate-python-job.yml
@@ -10,7 +10,7 @@ parameters:
 jobs:
   - job: validate_python
     displayName: Validate python
-    pool: $(parameters.pool)
+    pool: '$(parameters.pool)'
     steps:
     - task: AzureCLI@2
       displayName: 'Install dependencies and validate code'

--- a/pipeline-steps/templates/jobs/validate-python-job.yml
+++ b/pipeline-steps/templates/jobs/validate-python-job.yml
@@ -1,0 +1,33 @@
+parameters:
+- name: testDirectory
+  type: string
+- name: azureSubscriptionName
+  type: string
+- name: pool
+  type: string
+- name: environment
+  type: string
+  default: test
+
+#Assumes that python/pip/venv have already been installed
+jobs:
+  - job: validate_python
+    displayName: Validate python
+    pool: $(parameters.pool)
+    steps:
+    - task: AzureCLI@2
+      displayName: 'Install dependencies and validate code'
+      inputs:
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -e
+          python3 -m venv working_dir
+          source working_dir/bin/activate
+          pip3 install -U pip
+          pip3 install -r requirements.txt --no-cache-dir
+          printf "\n\n\n\n\nBeginning code validation\n"
+          flake8 $(parameters.testDirectory)
+          echo "Code validation complete"
+          deactivate
+        azureSubscription: '$(parameters.azureSubscriptionName)-${{ upper(parameters.environment) }}'

--- a/pipeline-steps/templates/jobs/validate-python-job.yml
+++ b/pipeline-steps/templates/jobs/validate-python-job.yml
@@ -24,7 +24,7 @@ jobs:
           pip3 install -U pip
           pip3 install -r requirements.txt --no-cache-dir
           printf "\n\n\n\n\nBeginning code validation\n"
-          flake8 $(parameters.testDirectory)
+          flake8 $(parameters.testDirectory) || echo "Warning - The code has styling issues that must be resolved"
           echo "Code validation complete"
           deactivate
         azureSubscription: '$(parameters.azureSubscriptionName)'

--- a/pipeline-steps/templates/jobs/validate-python-job.yml
+++ b/pipeline-steps/templates/jobs/validate-python-job.yml
@@ -5,6 +5,9 @@ parameters:
   type: string
 - name: pool
   type: string
+- name: pythonVersion
+  type: string
+  default: 3
 
 #Assumes that python/pip/venv have already been installed
 jobs:
@@ -19,10 +22,10 @@ jobs:
       scriptLocation: inlineScript
       inlineScript: |
         set -e
-        python3 -m venv working_dir
+        python${{ parameters.pythonVersion}} -m venv working_dir
         source working_dir/bin/activate
-        pip3 install -U pip
-        pip3 install -r requirements.txt --no-cache-dir
+        pip${{ parameters.pythonVersion}} install -U pip
+        pip${{ parameters.pythonVersion}} install -r requirements.txt --no-cache-dir
         printf "\n\n\n\n\nBeginning code validation\n"
         flake8 ${{ parameters.testDirectory }} || echo "Warning - The code has styling issues that must be resolved"
         echo "Code validation complete"

--- a/pipeline-steps/templates/jobs/validate-python-job.yml
+++ b/pipeline-steps/templates/jobs/validate-python-job.yml
@@ -8,23 +8,23 @@ parameters:
 
 #Assumes that python/pip/venv have already been installed
 jobs:
-  - job: validate_python
-    displayName: Validate python
-    pool: '$(parameters.pool)'
-    steps:
-    - task: AzureCLI@2
-      displayName: 'Install dependencies and validate code'
-      inputs:
-        scriptType: bash
-        scriptLocation: inlineScript
-        inlineScript: |
-          set -e
-          python3 -m venv working_dir
-          source working_dir/bin/activate
-          pip3 install -U pip
-          pip3 install -r requirements.txt --no-cache-dir
-          printf "\n\n\n\n\nBeginning code validation\n"
-          flake8 $(parameters.testDirectory) || echo "Warning - The code has styling issues that must be resolved"
-          echo "Code validation complete"
-          deactivate
-        azureSubscription: '$(parameters.azureSubscriptionName)'
+- job: validate_python
+  displayName: Validate python
+  pool: '$(parameters.pool)'
+  steps:
+  - task: AzureCLI@2
+    displayName: 'Install dependencies and validate code'
+    inputs:
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -e
+        python3 -m venv working_dir
+        source working_dir/bin/activate
+        pip3 install -U pip
+        pip3 install -r requirements.txt --no-cache-dir
+        printf "\n\n\n\n\nBeginning code validation\n"
+        flake8 $(parameters.testDirectory) || echo "Warning - The code has styling issues that must be resolved"
+        echo "Code validation complete"
+        deactivate
+      azureSubscription: '$(parameters.azureSubscriptionName)'

--- a/pipeline-steps/templates/jobs/validate-python-job.yml
+++ b/pipeline-steps/templates/jobs/validate-python-job.yml
@@ -5,9 +5,6 @@ parameters:
   type: string
 - name: pool
   type: string
-- name: environment
-  type: string
-  default: test
 
 #Assumes that python/pip/venv have already been installed
 jobs:
@@ -30,4 +27,4 @@ jobs:
           flake8 $(parameters.testDirectory)
           echo "Code validation complete"
           deactivate
-        azureSubscription: '$(parameters.azureSubscriptionName)-${{ upper(parameters.environment) }}'
+        azureSubscription: '$(parameters.azureSubscriptionName)'

--- a/pipeline-steps/templates/jobs/validate-python-job.yml
+++ b/pipeline-steps/templates/jobs/validate-python-job.yml
@@ -16,7 +16,7 @@ jobs:
   pool: ${{ parameters.pool }}
   steps:
   - task: AzureCLI@2
-    displayName: 'Install dependencies and validate code'
+    displayName: 'Validate code'
     inputs:
       scriptType: bash
       scriptLocation: inlineScript

--- a/pipeline-steps/templates/jobs/validate-python-job.yml
+++ b/pipeline-steps/templates/jobs/validate-python-job.yml
@@ -10,7 +10,7 @@ parameters:
 jobs:
 - job: validate_python
   displayName: Validate python
-  pool: '$(parameters.pool)'
+  pool: $(parameters.pool)
   steps:
   - task: AzureCLI@2
     displayName: 'Install dependencies and validate code'
@@ -27,4 +27,4 @@ jobs:
         flake8 $(parameters.testDirectory) || echo "Warning - The code has styling issues that must be resolved"
         echo "Code validation complete"
         deactivate
-      azureSubscription: '$(parameters.azureSubscriptionName)'
+      azureSubscription: $(parameters.azureSubscriptionName)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RMI-2477
https://tools.hmcts.net/jira/browse/RMI-2502


A warning message has been added so that the step can be used in all libraries. This warning message will be removed when https://tools.hmcts.net/jira/browse/RMI-2502 is complete

### Change description ###
Add job that runs python code validation using flake8, that fails the pipeline if the python code has bad styling


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
