### PR TITLE
Update windows VM version for sql validate

### DIFF
--- a/pipeline-steps/templates/jobs/validate-sql-job.yaml
+++ b/pipeline-steps/templates/jobs/validate-sql-job.yaml
@@ -27,7 +27,7 @@ jobs:
       pathToPublish: '${{ parameters.sqlPath }}/bin/${{ parameters.buildConfiguration }}/${{ parameters.dacpacName }}.dacpac'
 
   pool:
-      vmImage: 'windows-2019'
+      vmImage: 'windows-latest'
   steps:
   - task: NuGetToolInstaller@1
 

--- a/pipeline-steps/templates/jobs/validate-sql-job.yaml
+++ b/pipeline-steps/templates/jobs/validate-sql-job.yaml
@@ -27,7 +27,7 @@ jobs:
       pathToPublish: '${{ parameters.sqlPath }}/bin/${{ parameters.buildConfiguration }}/${{ parameters.dacpacName }}.dacpac'
 
   pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2022'
   steps:
   - task: NuGetToolInstaller@1
 


### PR DESCRIPTION
windows-2019 is deprecated, windows-2025 is latest but windows-2022 is the current stable and same as the windows-latest version.